### PR TITLE
Fixes reading of config

### DIFF
--- a/src/main/java/com/aesireanempire/eplus/handlers/ConfigurationHandler.java
+++ b/src/main/java/com/aesireanempire/eplus/handlers/ConfigurationHandler.java
@@ -96,7 +96,7 @@ public class ConfigurationHandler
     {
         try
         {
-            Class<?> clazz = Class.forName("eplus.lib.ConfigurationSettings");
+            Class<?> clazz = Class.forName("com.aesireanempire.eplus.lib.ConfigurationSettings");
             Field field = clazz.getDeclaredField(setting);
 
             int value = field.getInt(null);


### PR DESCRIPTION
Fixes java.lang.ClassNotFoundException: eplus.lib.ConfigurationSettings, which caused the config not to be read.
